### PR TITLE
Fix ASDF loading of system math/ls-rotation.

### DIFF
--- a/math.asd
+++ b/math.asd
@@ -92,7 +92,7 @@
   :license "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007 or later"  
   :serial t
   :in-order-to ((test-op (test-op "math/ls-rotation/tests")))
-  ;; :depends-on ("math/arr-matr")
+  :depends-on ("math/matr")
   :components ((:module "src/ls-rotation"
 		:serial t
                 :components ((:file "ls-rotation")


### PR DESCRIPTION
The math/ls-rotation system includes file src/ls-rotation/ls-rotation.lisp, which refers to symbol MATH/MATR:ROWS.  The MATH/MATR package does not exist unless system math/matr has been loaded, so system math/ls-rotation needs to depend on system math/matr in file math.asd.